### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/higherintel-io/bc_extended_editor2.png?columns=all)](https://waffle.io/higherintel-io/bc_extended_editor2?utm_source=badge)
 # bc_extended_editor
 
 Extended Editor for BigCommerce.


### PR DESCRIPTION
Merge this to receive a badge indicating columns and number of cards in your columns on your waffle.io board at https://waffle.io/higherintel-io/bc_extended_editor2

This was requested by a real person (user qdhenry) on waffle.io, we're not trying to spam you.